### PR TITLE
feat: Auto-subscribe support rep to GitHub issues via @mention

### DIFF
--- a/Http/Controllers/GithubController.php
+++ b/Http/Controllers/GithubController.php
@@ -809,21 +809,32 @@ class GithubController extends Controller
                 'github.allowed_labels',
             ];
             
-            // Handle user mappings separately
-            $userMappings = $request->input('user_mappings', []);
-            if (is_array($userMappings)) {
+            // Handle user mappings separately (with defensive coding)
+            try {
+                $userMappings = $request->input('user_mappings', []);
                 $cleanedMappings = [];
-                foreach ($userMappings as $userId => $mapping) {
-                    $githubUsername = trim($mapping['github_username'] ?? '');
-                    if (!empty($githubUsername)) {
-                        $cleanedMappings[$userId] = [
-                            'user_id' => (int) $userId,
-                            'name' => $mapping['name'] ?? '',
-                            'github_username' => $githubUsername,
-                        ];
+                
+                if (is_array($userMappings)) {
+                    foreach ($userMappings as $userId => $mapping) {
+                        // Skip if mapping is not an array (defensive)
+                        if (!is_array($mapping)) {
+                            continue;
+                        }
+                        
+                        $githubUsername = isset($mapping['github_username']) ? trim($mapping['github_username']) : '';
+                        if (!empty($githubUsername)) {
+                            $cleanedMappings[$userId] = [
+                                'user_id' => (int) $userId,
+                                'name' => isset($mapping['name']) ? $mapping['name'] : '',
+                                'github_username' => $githubUsername,
+                            ];
+                        }
                     }
                 }
+                
                 \Option::set('github.user_mappings', json_encode($cleanedMappings));
+            } catch (\Exception $e) {
+                \Helper::log('github_settings', 'Error saving user mappings: ' . $e->getMessage());
             }
             
             foreach ($allowed as $key) {
@@ -960,6 +971,7 @@ class GithubController extends Controller
     
     /**
      * Get user mappings for the watchers dropdown
+     * Returns ALL active FreeScout users with their GitHub mappings (if any)
      */
     public function getUserMappings()
     {
@@ -967,15 +979,20 @@ class GithubController extends Controller
             $userMappings = json_decode(\Option::get('github.user_mappings', '{}'), true) ?: [];
             $currentUserId = auth()->id();
             
-            // Format for dropdown
+            // Get ALL active FreeScout users and include their GitHub mappings
+            $users = \App\User::where('status', \App\User::STATUS_ACTIVE)->orderBy('first_name')->get();
+            
             $mappings = [];
-            foreach ($userMappings as $userId => $mapping) {
-                if (!empty($mapping['github_username'])) {
+            foreach ($users as $user) {
+                $githubUsername = $userMappings[$user->id]['github_username'] ?? '';
+                
+                // Only include users who have a GitHub username mapped
+                if (!empty($githubUsername)) {
                     $mappings[] = [
-                        'user_id' => (int) $userId,
-                        'name' => $mapping['name'] ?? '',
-                        'github_username' => $mapping['github_username'],
-                        'is_current_user' => ((int) $userId === $currentUserId),
+                        'user_id' => (int) $user->id,
+                        'name' => $user->getFullName(),
+                        'github_username' => $githubUsername,
+                        'is_current_user' => ((int) $user->id === $currentUserId),
                     ];
                 }
             }
@@ -990,7 +1007,7 @@ class GithubController extends Controller
             
             return response()->json([
                 'status' => 'error',
-                'message' => 'Failed to load user mappings'
+                'message' => 'Failed to load user mappings: ' . $e->getMessage()
             ], 500);
         }
     }

--- a/Http/Controllers/GithubController.php
+++ b/Http/Controllers/GithubController.php
@@ -976,7 +976,8 @@ class GithubController extends Controller
     public function getUserMappings()
     {
         try {
-            $userMappings = json_decode(\Option::get('github.user_mappings', '{}'), true) ?: [];
+            $rawMappings = \Option::get('github.user_mappings', '{}');
+            $userMappings = is_array($rawMappings) ? $rawMappings : (json_decode($rawMappings, true) ?: []);
             $currentUserId = auth()->id();
             
             // Get ALL active FreeScout users and include their GitHub mappings

--- a/Http/Controllers/GithubController.php
+++ b/Http/Controllers/GithubController.php
@@ -423,7 +423,8 @@ class GithubController extends Controller
             'title' => 'nullable|string|max:255',
             'body' => 'nullable|string',
             'labels' => 'nullable|array',
-            'assignees' => 'nullable|array'
+            'assignees' => 'nullable|array',
+            'watchers' => 'nullable|array'
         ]);
 
         $conversation = \App\Conversation::with('customer')->findOrFail($request->get('conversation_id'));
@@ -445,6 +446,7 @@ class GithubController extends Controller
         $body = $request->get('body');
         $labels = $request->get('labels', []) ?: [];
         $assignees = $request->get('assignees', []) ?: [];
+        $watchers = $request->get('watchers', []) ?: [];
 
         try {
             // Check global settings for auto-generation
@@ -487,8 +489,8 @@ class GithubController extends Controller
             // Note: Label assignment is now handled above in the AI content generation
             // to avoid duplicate AI calls. Labels are already assigned from generatedContent['suggested_labels']
 
-            // Create the issue
-            $result = GithubApiClient::createIssue($repository, $title, $body, $labels, $assignees);
+            // Create the issue (pass watchers for @mention auto-subscription)
+            $result = GithubApiClient::createIssue($repository, $title, $body, $labels, $assignees, $watchers);
 
             if ($result['status'] === 'success') {
                 // Link the issue to the conversation
@@ -807,6 +809,23 @@ class GithubController extends Controller
                 'github.allowed_labels',
             ];
             
+            // Handle user mappings separately
+            $userMappings = $request->input('user_mappings', []);
+            if (is_array($userMappings)) {
+                $cleanedMappings = [];
+                foreach ($userMappings as $userId => $mapping) {
+                    $githubUsername = trim($mapping['github_username'] ?? '');
+                    if (!empty($githubUsername)) {
+                        $cleanedMappings[$userId] = [
+                            'user_id' => (int) $userId,
+                            'name' => $mapping['name'] ?? '',
+                            'github_username' => $githubUsername,
+                        ];
+                    }
+                }
+                \Option::set('github.user_mappings', json_encode($cleanedMappings));
+            }
+            
             foreach ($allowed as $key) {
                 try {
                     if (array_key_exists($key, $settings)) {
@@ -939,6 +958,43 @@ class GithubController extends Controller
         }
     }
     
+    /**
+     * Get user mappings for the watchers dropdown
+     */
+    public function getUserMappings()
+    {
+        try {
+            $userMappings = json_decode(\Option::get('github.user_mappings', '{}'), true) ?: [];
+            $currentUserId = auth()->id();
+            
+            // Format for dropdown
+            $mappings = [];
+            foreach ($userMappings as $userId => $mapping) {
+                if (!empty($mapping['github_username'])) {
+                    $mappings[] = [
+                        'user_id' => (int) $userId,
+                        'name' => $mapping['name'] ?? '',
+                        'github_username' => $mapping['github_username'],
+                        'is_current_user' => ((int) $userId === $currentUserId),
+                    ];
+                }
+            }
+            
+            return response()->json([
+                'status' => 'success',
+                'data' => $mappings,
+                'current_user_id' => $currentUserId,
+            ]);
+        } catch (\Exception $e) {
+            \Helper::logException($e, '[GitHub] Get User Mappings Error');
+            
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Failed to load user mappings'
+            ], 500);
+        }
+    }
+
     /**
      * Test token and show detailed API responses
      */

--- a/Http/routes.php
+++ b/Http/routes.php
@@ -31,6 +31,9 @@ Route::group([
     Route::get('/github/label-mappings', 'GithubController@getLabelMappings')->name('github.label_mappings');
     Route::post('/github/label-mappings', 'GithubController@saveLabelMappings')->name('github.save_label_mappings');
     
+    // User mapping routes (for watchers dropdown)
+    Route::get('/github/user-mappings', 'GithubController@getUserMappings')->name('github.user_mappings');
+    
 });
 
 // Public webhook route (no middleware - external access required)

--- a/Public/js/laroute.js
+++ b/Public/js/laroute.js
@@ -61,6 +61,10 @@
             "name": "github.save_label_mappings"
         },
         {
+            "uri": "github\/user-mappings",
+            "name": "github.user_mappings"
+        },
+        {
             "uri": "github\/save-settings",
             "name": "github.save_settings"
         },

--- a/Public/js/module.js
+++ b/Public/js/module.js
@@ -15,7 +15,9 @@ var GitHub = {
         loadingCallbacks: [],
         repoSearchTimers: {},
         activeRepoRequests: {},
-        lastThrottleNotice: 0
+        lastThrottleNotice: 0,
+        userMappings: null,
+        userMappingsLoading: false
     },
     warningsShown: [], // Track warnings to prevent duplicates
     state: {
@@ -313,6 +315,24 @@ function githubInitModals() {
                 // Clear selection after form reset
                 labelsSelect.val(null).trigger('change');
             }
+            
+            // Initialize watchers multiselect with Select2 and load user mappings
+            var watchersSelect = $('#github-issue-watchers');
+            if (!watchersSelect.hasClass('select2-hidden-accessible')) {
+                watchersSelect.select2({
+                    placeholder: 'Select watchers...',
+                    allowClear: true,
+                    closeOnSelect: false,
+                    width: '100%',
+                    dropdownParent: $('#github-create-issue-modal'),
+                    dropdownCssClass: 'github-select2-dropdown'
+                });
+            }
+            
+            // Load user mappings and populate watchers dropdown
+            githubLoadUserMappings(function(mappings) {
+                githubPopulateWatchersDropdown(watchersSelect, mappings);
+            });
             
             // Restore default repository after form reset
             githubEnsureRepositoryCache(function() {
@@ -1088,6 +1108,103 @@ function githubPopulateLabels(labels) {
         }
     });
     
+}
+
+/**
+ * Load user mappings from server for watchers dropdown
+ */
+function githubLoadUserMappings(callback) {
+    // Return cached mappings if available
+    if (GitHub.cache.userMappings !== null) {
+        if (typeof callback === 'function') {
+            callback(GitHub.cache.userMappings);
+        }
+        return;
+    }
+    
+    // Prevent duplicate requests
+    if (GitHub.cache.userMappingsLoading) {
+        return;
+    }
+    
+    GitHub.cache.userMappingsLoading = true;
+    
+    $.ajax({
+        url: laroute.route('github.user_mappings'),
+        type: 'GET',
+        success: function(response) {
+            GitHub.cache.userMappingsLoading = false;
+            
+            if (response.status === 'success') {
+                GitHub.cache.userMappings = response.data || [];
+                if (typeof callback === 'function') {
+                    callback(GitHub.cache.userMappings);
+                }
+            } else {
+                console.error('Failed to load user mappings:', response.message);
+                GitHub.cache.userMappings = [];
+                if (typeof callback === 'function') {
+                    callback([]);
+                }
+            }
+        },
+        error: function(xhr) {
+            GitHub.cache.userMappingsLoading = false;
+            console.error('Failed to load user mappings:', xhr);
+            GitHub.cache.userMappings = [];
+            if (typeof callback === 'function') {
+                callback([]);
+            }
+        }
+    });
+}
+
+/**
+ * Populate watchers dropdown with user mappings
+ * Defaults to selecting the current user if they have a mapping
+ */
+function githubPopulateWatchersDropdown(select, mappings) {
+    if (!select || !select.length) {
+        return;
+    }
+    
+    // Destroy existing Select2 if it exists
+    if (select.hasClass('select2-hidden-accessible')) {
+        select.select2('destroy');
+    }
+    
+    select.empty();
+    
+    var currentUserValue = null;
+    
+    $.each(mappings, function(i, mapping) {
+        var option = $('<option></option>')
+            .attr('value', mapping.github_username)
+            .attr('data-user-id', mapping.user_id)
+            .text(mapping.name + ' (@' + mapping.github_username + ')');
+        
+        select.append(option);
+        
+        // Track current user for default selection
+        if (mapping.is_current_user) {
+            currentUserValue = mapping.github_username;
+        }
+    });
+    
+    // Re-initialize Select2
+    select.select2({
+        placeholder: 'Select watchers...',
+        allowClear: true,
+        closeOnSelect: false,
+        width: '100%',
+        dropdownParent: $('#github-create-issue-modal'),
+        dropdownCssClass: 'github-select2-dropdown'
+    });
+    
+    // Default to selecting current user if they have a mapping
+    if (currentUserValue) {
+        select.val([currentUserValue]).trigger('change');
+    }
 }
 
 function githubLoadLabelMappings(repository) {

--- a/Resources/views/partials/sidebar.blade.php
+++ b/Resources/views/partials/sidebar.blade.php
@@ -166,11 +166,6 @@
                         </div>
                     </div>
                     
-                    <div class="form-group">
-                        <label for="github-issue-assignees">{{ __('Assignees') }}</label>
-                        <input type="text" class="form-control" name="assignees" id="github-issue-assignees" placeholder="{{ __('GitHub usernames (comma-separated)') }}">
-                    </div>
-                    
                 </form>
             </div>
             <div class="modal-footer">

--- a/Resources/views/partials/sidebar.blade.php
+++ b/Resources/views/partials/sidebar.blade.php
@@ -157,10 +157,18 @@
                         </div>
                         <div class="col-md-6">
                             <div class="form-group">
-                                <label for="github-issue-assignees">{{ __('Assignees') }}</label>
-                                <input type="text" class="form-control" name="assignees" id="github-issue-assignees" placeholder="{{ __('GitHub usernames (comma-separated)') }}">
+                                <label for="github-issue-watchers">{{ __('Watchers') }}</label>
+                                <select class="form-control" name="watchers[]" id="github-issue-watchers" multiple data-placeholder="{{ __('Select watchers...') }}">
+                                    <!-- Watchers will be populated via JavaScript from user mappings -->
+                                </select>
+                                <p class="help-block small text-muted">{{ __('Selected users will be @mentioned and auto-subscribed to notifications.') }}</p>
                             </div>
                         </div>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="github-issue-assignees">{{ __('Assignees') }}</label>
+                        <input type="text" class="form-control" name="assignees" id="github-issue-assignees" placeholder="{{ __('GitHub usernames (comma-separated)') }}">
                     </div>
                     
                 </form>

--- a/Resources/views/settings.blade.php
+++ b/Resources/views/settings.blade.php
@@ -257,14 +257,52 @@ JSON format:
             </div>
         </div>
 
-        <div class="form-group{{ $errors->has('github.default_watcher') ? ' has-error' : '' }}">
-            <label for="github_default_watcher" class="col-sm-2 control-label">{{ __('Default GitHub Watcher') }}</label>
-            <div class="col-sm-6">
-                <input type="text" class="form-control" name="settings[github.default_watcher]" id="github_default_watcher" value="{{ old('settings.github.default_watcher', \Option::get('github.default_watcher')) }}" placeholder="{{ __('e.g., jack-arturo') }}">
-                @include('partials/field_error', ['field'=>'github.default_watcher'])
-                <p class="form-help">
-                    {{ __('GitHub username to @mention when creating issues. This user will be automatically subscribed to receive notifications (e.g., from CodeRabbit, CI).') }}
-                </p>
+        <!-- User Mapping Section -->
+        <div class="form-group">
+            <label class="col-sm-2 control-label">{{ __('User GitHub Mappings') }}</label>
+            <div class="col-sm-8">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h4 class="panel-title">
+                            {{ __('FreeScout User → GitHub Username') }}
+                        </h4>
+                    </div>
+                    <div class="panel-body">
+                        <p class="text-muted small">
+                            {{ __('Map FreeScout users to their GitHub usernames. Users with mappings can be selected as "Watchers" when creating issues - they\'ll be @mentioned and auto-subscribed to notifications.') }}
+                        </p>
+                        <table class="table table-condensed" id="github-user-mappings-table">
+                            <thead>
+                                <tr>
+                                    <th>{{ __('FreeScout User') }}</th>
+                                    <th>{{ __('GitHub Username') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @php
+                                    $users = \App\User::where('status', \App\User::STATUS_ACTIVE)->orderBy('first_name')->get();
+                                    $userMappings = json_decode(\Option::get('github.user_mappings', '{}'), true) ?: [];
+                                @endphp
+                                @foreach($users as $user)
+                                    <tr>
+                                        <td>
+                                            <strong>{{ $user->getFullName() }}</strong>
+                                            <br><small class="text-muted">{{ $user->email }}</small>
+                                            <input type="hidden" name="user_mappings[{{ $user->id }}][user_id]" value="{{ $user->id }}">
+                                            <input type="hidden" name="user_mappings[{{ $user->id }}][name]" value="{{ $user->getFullName() }}">
+                                        </td>
+                                        <td>
+                                            <input type="text" class="form-control input-sm" 
+                                                   name="user_mappings[{{ $user->id }}][github_username]" 
+                                                   value="{{ $userMappings[$user->id]['github_username'] ?? '' }}"
+                                                   placeholder="{{ __('e.g., octocat') }}">
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/Resources/views/settings.blade.php
+++ b/Resources/views/settings.blade.php
@@ -257,6 +257,17 @@ JSON format:
             </div>
         </div>
 
+        <div class="form-group{{ $errors->has('github.default_watcher') ? ' has-error' : '' }}">
+            <label for="github_default_watcher" class="col-sm-2 control-label">{{ __('Default GitHub Watcher') }}</label>
+            <div class="col-sm-6">
+                <input type="text" class="form-control" name="settings[github.default_watcher]" id="github_default_watcher" value="{{ old('settings.github.default_watcher', \Option::get('github.default_watcher')) }}" placeholder="{{ __('e.g., jack-arturo') }}">
+                @include('partials/field_error', ['field'=>'github.default_watcher'])
+                <p class="form-help">
+                    {{ __('GitHub username to @mention when creating issues. This user will be automatically subscribed to receive notifications (e.g., from CodeRabbit, CI).') }}
+                </p>
+            </div>
+        </div>
+
 
         <div class="form-group">
             <label for="github_allowed_labels" class="col-sm-2 control-label">{{ __('Allowed Auto-assign Labels') }}</label>

--- a/Resources/views/settings.blade.php
+++ b/Resources/views/settings.blade.php
@@ -281,7 +281,9 @@ JSON format:
                             <tbody>
                                 @php
                                     $users = \App\User::where('status', \App\User::STATUS_ACTIVE)->orderBy('first_name')->get();
-                                    $userMappings = json_decode(\Option::get('github.user_mappings', '{}'), true) ?: [];
+                                    $rawMappings = \Option::get('github.user_mappings', '{}');
+                                    // Handle both string (JSON) and array (already decoded) cases
+                                    $userMappings = is_array($rawMappings) ? $rawMappings : (json_decode($rawMappings, true) ?: []);
                                 @endphp
                                 @foreach($users as $user)
                                     <tr>

--- a/Services/GithubApiClient.php
+++ b/Services/GithubApiClient.php
@@ -524,7 +524,8 @@ class GithubApiClient
             
             // Create remote link back to FreeScout if enabled
             if (\Option::get('github.create_remote_link', true)) {
-                self::createRemoteLink($repository, $response['data']['number']);
+                $watcher = \Option::get('github.default_watcher');
+                self::createRemoteLink($repository, $response['data']['number'], $watcher);
             }
 
             return [
@@ -554,13 +555,25 @@ class GithubApiClient
 
     /**
      * Create remote link in GitHub issue pointing back to FreeScout
+     * 
+     * @param string $repository Repository full name (owner/repo)
+     * @param int $issue_number Issue number
+     * @param string|null $watcher_username GitHub username to @mention (auto-subscribes them)
      */
-    private static function createRemoteLink($repository, $issue_number)
+    private static function createRemoteLink($repository, $issue_number, $watcher_username = null)
     {
         // This would require additional GitHub API calls or webhook setup
         // For now, we'll add a comment to the issue with the FreeScout link
         $freescout_url = url('/');
-        $comment_body = "🔗 **FreeScout Link**: This issue was created from FreeScout support system.\n\n" .
+        
+        // @mention the watcher to auto-subscribe them to the issue
+        // Being @mentioned in an issue automatically subscribes you to notifications
+        $mention = '';
+        if (!empty($watcher_username)) {
+            $mention = "@{$watcher_username} ";
+        }
+        
+        $comment_body = "{$mention}🔗 **FreeScout Link**: This issue was created from FreeScout support system.\n\n" .
                        "View original conversation: {$freescout_url}";
 
         self::apiCall("repos/{$repository}/issues/{$issue_number}/comments", [

--- a/Services/GithubApiClient.php
+++ b/Services/GithubApiClient.php
@@ -500,8 +500,15 @@ class GithubApiClient
 
     /**
      * Create new issue
+     * 
+     * @param string $repository Repository full name (owner/repo)
+     * @param string $title Issue title
+     * @param string $body Issue body
+     * @param array $labels Labels to assign
+     * @param array $assignees GitHub usernames to assign
+     * @param array $watchers GitHub usernames to @mention (auto-subscribes them)
      */
-    public static function createIssue($repository, $title, $body = '', $labels = [], $assignees = [])
+    public static function createIssue($repository, $title, $body = '', $labels = [], $assignees = [], $watchers = [])
     {
         $params = [
             'title' => $title,
@@ -524,8 +531,7 @@ class GithubApiClient
             
             // Create remote link back to FreeScout if enabled
             if (\Option::get('github.create_remote_link', true)) {
-                $watcher = \Option::get('github.default_watcher');
-                self::createRemoteLink($repository, $response['data']['number'], $watcher);
+                self::createRemoteLink($repository, $response['data']['number'], $watchers);
             }
 
             return [
@@ -558,22 +564,28 @@ class GithubApiClient
      * 
      * @param string $repository Repository full name (owner/repo)
      * @param int $issue_number Issue number
-     * @param string|null $watcher_username GitHub username to @mention (auto-subscribes them)
+     * @param array $watchers GitHub usernames to @mention (auto-subscribes them)
      */
-    private static function createRemoteLink($repository, $issue_number, $watcher_username = null)
+    private static function createRemoteLink($repository, $issue_number, $watchers = [])
     {
         // This would require additional GitHub API calls or webhook setup
         // For now, we'll add a comment to the issue with the FreeScout link
         $freescout_url = url('/');
         
-        // @mention the watcher to auto-subscribe them to the issue
+        // @mention watchers to auto-subscribe them to the issue
         // Being @mentioned in an issue automatically subscribes you to notifications
-        $mention = '';
-        if (!empty($watcher_username)) {
-            $mention = "@{$watcher_username} ";
+        $mentions = '';
+        if (!empty($watchers) && is_array($watchers)) {
+            $mentionList = array_map(function($username) {
+                return '@' . trim($username);
+            }, array_filter($watchers));
+            
+            if (!empty($mentionList)) {
+                $mentions = implode(' ', $mentionList) . ' ';
+            }
         }
         
-        $comment_body = "{$mention}🔗 **FreeScout Link**: This issue was created from FreeScout support system.\n\n" .
+        $comment_body = "{$mentions}🔗 **FreeScout Link**: This issue was created from FreeScout support system.\n\n" .
                        "View original conversation: {$freescout_url}";
 
         self::apiCall("repos/{$repository}/issues/{$issue_number}/comments", [


### PR DESCRIPTION
## Summary

Addresses #2 - Auto-subscribes support agents to GitHub issues via @mention.

## Solution

Full user mapping system + watchers dropdown in the create issue modal.

### Settings Page
- **User Mapping Table**: Shows all active FreeScout users with GitHub username fields
- Stored as JSON in Options table (no database schema changes needed)

### Create Issue Modal
- **Watchers Dropdown**: Multi-select populated from user mappings
- Defaults to current user if they have a GitHub username mapped
- Selected users get @mentioned in the FreeScout link comment
- @mentioned users are auto-subscribed to issue notifications (CodeRabbit, CI, etc.)

## Changes

| File | Change |
|------|--------|
| `settings.blade.php` | User mapping table |
| `GithubController.php` | `getUserMappings()` endpoint, save mappings in `saveSettings()` |
| `sidebar.blade.php` | Watchers dropdown in modal |
| `GithubApiClient.php` | `createIssue()` accepts watchers[], `createRemoteLink()` @mentions them |
| `module.js` | `githubLoadUserMappings()`, `githubPopulateWatchersDropdown()` |
| `routes.php`, `laroute.js` | New route for user mappings endpoint |

## Usage

1. **Settings**: Go to GitHub module settings → fill in GitHub usernames for your team
2. **Create Issue**: Open modal → select watchers (defaults to you) → create issue
3. **Result**: Selected users get @mentioned in the FreeScout link comment
4. **Notifications**: @mentioned users auto-subscribe to the issue (get CodeRabbit, CI notifications)

## Screenshot

The modal now has a "Watchers" dropdown between Labels and Assignees.

Closes #2